### PR TITLE
Adds whitelist option. Closes #1

### DIFF
--- a/lib/non-stupid-digest-assets.rb
+++ b/lib/non-stupid-digest-assets.rb
@@ -1,22 +1,36 @@
 module NonStupidDigestAssets
   mattr_accessor :whitelist
   @@whitelist = []
+
+  class << self
+    def files(files)
+      return files if whitelist.empty?
+      whitelisted_files(files)
+    end
+
+    private
+
+    def whitelisted_files(files)
+      files.select do |file, info|
+        whitelist.any? do |item|
+          case item
+          when Regexp
+            info['logical_path'] =~ item
+          else
+            info['logical_path'] == item
+          end
+        end
+      end
+    end
+  end
 end
 
 module Sprockets
   class Manifest
     def compile_with_non_digest *args
       compile_without_non_digest *args
-      if NonStupidDigestAssets.whitelist.empty?
-        files_to_copy = files
-      else
-        files_to_copy = files.select do |file, info|
-          !NonStupidDigestAssets.whitelist.detect do |item|
-            info['logical_path'] =~ /#{item}/
-          end.nil?
-        end
-      end
-      files_to_copy.each do |(digest_path, info)|
+
+      NonStupidDigestAssets.files(files).each do |(digest_path, info)|
         full_digest_path = File.join dir, digest_path
         full_digest_gz_path = "#{full_digest_path}.gz"
         full_non_digest_path = File.join dir, info['logical_path']


### PR DESCRIPTION
You can now set a whitelist of file paths that should be copied to a non digest version.
### Usage example

Add an initializer into `config/initializers` folder:

```
# config/initializers/non_digest_assets.rb
NonStupidDigestAssets.whitelist = ['tinymce/']
```

Have fun \o/
