### PR TITLE
Eliminate failures for missing files (and subsequent Capistrano 2.x rollback)

### DIFF
--- a/lib/non-stupid-digest-assets.rb
+++ b/lib/non-stupid-digest-assets.rb
@@ -8,8 +8,10 @@ module Sprockets
         full_digest_gz_path = "#{full_digest_path}.gz"
         full_non_digest_path = File.join dir, info['logical_path']
         full_non_digest_gz_path = "#{full_non_digest_path}.gz"
-        logger.info "Writing #{full_non_digest_path}"
-        FileUtils.cp full_digest_path, full_non_digest_path
+	if File.exists? full_digest_path
+          logger.info "Writing #{full_non_digest_path}"
+          FileUtils.cp full_digest_path, full_non_digest_path
+	end
         if File.exists? full_digest_gz_path
           logger.info "Writing #{full_non_digest_gz_path}"
           FileUtils.cp full_digest_gz_path, full_non_digest_gz_path


### PR DESCRIPTION
Hi Alex,

I was getting some errors during Capistrano 2.x deployment and had to disable 'non-stupid-digest-assets' temporarily. This adds a test before copy (similar to the GZipped assets). However, it seems to be searching for a digest that doesn't exist - so maybe this is just a workaround.

Cheers,

Nigel

``` shell
[nigel@kasify01 20131208030633]$ rake assets:precompile RAILS_ENV=test
I, [2013-12-08T03:11:25.378354 #8195]  INFO -- : Writing /u/apps/Kasify/staging/releases/20131208030633/public/assets/modernizr.js
I, [2013-12-08T03:11:25.402920 #8195]  INFO -- : Writing /u/apps/Kasify/staging/releases/20131208030633/public/assets/modernizr.js.gz
I, [2013-12-08T03:11:25.415295 #8195]  INFO -- : Writing /u/apps/Kasify/staging/releases/20131208030633/public/assets/jquery-ui/animated-overlay.gif
I, [2013-12-08T03:11:25.418102 #8195]  INFO -- : Writing /u/apps/Kasify/staging/releases/20131208030633/public/assets/jquery-ui/ui-bg_flat_0_aaaaaa_40x100.png
I, [2013-12-08T03:11:25.419328 #8195]  INFO -- : Writing /u/apps/Kasify/staging/releases/20131208030633/public/assets/jquery-ui/ui-bg_flat_75_ffffff_40x100.png
I, [2013-12-08T03:11:25.427465 #8195]  INFO -- : Writing /u/apps/Kasify/staging/releases/20131208030633/public/assets/jquery-ui/ui-bg_glass_55_fbf9ee_1x400.png
I, [2013-12-08T03:11:25.428725 #8195]  INFO -- : Writing /u/apps/Kasify/staging/releases/20131208030633/public/assets/jquery-ui/ui-bg_glass_65_ffffff_1x400.png
I, [2013-12-08T03:11:25.429553 #8195]  INFO -- : Writing /u/apps/Kasify/staging/releases/20131208030633/public/assets/jquery-ui/ui-bg_glass_75_dadada_1x400.png
I, [2013-12-08T03:11:25.434714 #8195]  INFO -- : Writing /u/apps/Kasify/staging/releases/20131208030633/public/assets/jquery-ui/ui-bg_glass_75_e6e6e6_1x400.png
I, [2013-12-08T03:11:25.435943 #8195]  INFO -- : Writing /u/apps/Kasify/staging/releases/20131208030633/public/assets/jquery-ui/ui-bg_glass_95_fef1ec_1x400.png
I, [2013-12-08T03:11:25.436971 #8195]  INFO -- : Writing /u/apps/Kasify/staging/releases/20131208030633/public/assets/jquery-ui/ui-bg_highlight-soft_75_cccccc_1x100.png
I, [2013-12-08T03:11:25.438036 #8195]  INFO -- : Writing /u/apps/Kasify/staging/releases/20131208030633/public/assets/jquery-ui/ui-icons_222222_256x240.png
I, [2013-12-08T03:11:25.439052 #8195]  INFO -- : Writing /u/apps/Kasify/staging/releases/20131208030633/public/assets/jquery-ui/ui-icons_2e83ff_256x240.png
I, [2013-12-08T03:11:25.439956 #8195]  INFO -- : Writing /u/apps/Kasify/staging/releases/20131208030633/public/assets/jquery-ui/ui-icons_454545_256x240.png
I, [2013-12-08T03:11:25.441162 #8195]  INFO -- : Writing /u/apps/Kasify/staging/releases/20131208030633/public/assets/jquery-ui/ui-icons_888888_256x240.png
I, [2013-12-08T03:11:25.442698 #8195]  INFO -- : Writing /u/apps/Kasify/staging/releases/20131208030633/public/assets/jquery-ui/ui-icons_cd0a0a_256x240.png
I, [2013-12-08T03:11:25.444045 #8195]  INFO -- : Writing /u/apps/Kasify/staging/releases/20131208030633/public/assets/issues/action1.html
I, [2013-12-08T03:11:25.451768 #8195]  INFO -- : Writing /u/apps/Kasify/staging/releases/20131208030633/public/assets/issues/action1.html.gz
I, [2013-12-08T03:11:25.453555 #8195]  INFO -- : Writing /u/apps/Kasify/staging/releases/20131208030633/public/assets/issues/default.html
I, [2013-12-08T03:11:25.453767 #8195]  INFO -- : Writing /u/apps/Kasify/staging/releases/20131208030633/public/assets/issues/send_communications.html
I, [2013-12-08T03:11:25.468824 #8195]  INFO -- : Writing /u/apps/Kasify/staging/releases/20131208030633/public/assets/issues/send_communications.html.gz
I, [2013-12-08T03:11:25.470771 #8195]  INFO -- : Writing /u/apps/Kasify/staging/releases/20131208030633/public/assets/application.js
rake aborted!
No such file or directory - /u/apps/Kasify/staging/releases/20131208030633/public/assets/application-75db7eb9471562a9ed86dda3a07c122a.js
/u/apps/Kasify/staging/shared/bundle/ruby/1.9.1/gems/non-stupid-digest-assets-1.0.1/lib/non-stupid-digest-assets.rb:12:in `block in compile_with_non_digest'
/u/apps/Kasify/staging/shared/bundle/ruby/1.9.1/gems/non-stupid-digest-assets-1.0.1/lib/non-stupid-digest-assets.rb:6:in `each'
/u/apps/Kasify/staging/shared/bundle/ruby/1.9.1/gems/non-stupid-digest-assets-1.0.1/lib/non-stupid-digest-assets.rb:6:in `compile_with_non_digest'
/u/apps/Kasify/staging/shared/bundle/ruby/1.9.1/gems/sprockets-rails-2.0.1/lib/sprockets/rails/task.rb:60:in `block (3 levels) in define'
/u/apps/Kasify/staging/shared/bundle/ruby/1.9.1/gems/sprockets-2.10.1/lib/rake/sprocketstask.rb:146:in `with_logger'
/u/apps/Kasify/staging/shared/bundle/ruby/1.9.1/gems/sprockets-rails-2.0.1/lib/sprockets/rails/task.rb:59:in `block (2 levels) in define'
Tasks: TOP => assets:precompile
(See full trace by running task with --trace)


[nigel@kasify01 20131208030633]$ cd public/assets/
[nigel@kasify01 assets]$ ls -la
total 8888
drwxrwx--- 4 nginx founders    4096 Dec  7 09:30 .
drwxrwx--- 9 nginx founders    4096 Sep 28 03:14 ..
-rwxrwx--- 1 nginx founders  198493 Nov 29 05:03 application-427d596ca3da1dec6758e41d252d917e.css
-rwxrwx--- 1 nginx founders   31423 Nov 29 05:03 application-427d596ca3da1dec6758e41d252d917e.css.gz
-rwxrwx--- 1 nginx founders 2080367 Nov 29 05:03 application-601d95ddae5293be69b4a7b39a29e066.js
-rwxrwx--- 1 nginx founders  509670 Nov 29 05:03 application-601d95ddae5293be69b4a7b39a29e066.js.gz
-rwxrwx--- 1 nginx founders  198924 Nov 29 05:56 application-608c784a513e3395420bce30b41dfc1f.css
-rwxrwx--- 1 nginx founders   31517 Nov 29 05:56 application-608c784a513e3395420bce30b41dfc1f.css.gz
-rwxrwx--- 1 nginx founders  200880 Dec  8 03:06 application-8e05d0afb4995295ac66a218fcd0ec63.css
-rwxrwx--- 1 nginx founders   31873 Dec  8 03:06 application-8e05d0afb4995295ac66a218fcd0ec63.css.gz
-rwxrwx--- 1 nginx founders 2134057 Dec  8 03:06 application-b17afb2e933ba1129fecd47cfd5a39a8.js
-rwxrwx--- 1 nginx founders  521823 Dec  8 03:06 application-b17afb2e933ba1129fecd47cfd5a39a8.js.gz
-rwxrwx--- 1 nginx founders  200880 Dec  8 03:06 application.css
-rwxrwx--- 1 nginx founders   31873 Dec  8 03:06 application.css.gz
-rwxrwx--- 1 nginx founders 2134057 Dec  8 03:06 application.js
-rwxrwx--- 1 nginx founders  521823 Dec  8 03:06 application.js.gz
drwxrwx--- 2 nginx founders    4096 Nov 29 05:57 issues
drwxrwx--- 2 nginx founders    4096 Nov 29 05:57 jquery-ui
-rwxrwx--- 1 nginx founders   11034 Dec  8 03:11 manifest-8ee9ba4981d6cd6a7dd484abfbd736c4.json
-rwxrwx--- 1 nginx founders   50145 Dec  8 03:06 modernizr-4aee2369324c6792ec12c6db4cc23751.js
-rwxrwx--- 1 nginx founders   15575 Dec  8 03:06 modernizr-4aee2369324c6792ec12c6db4cc23751.js.gz
-rwxrwx--- 1 nginx founders   50145 Nov 29 05:03 modernizr-5a6da2b38564a569777862a64bd1a526.js
-rwxrwx--- 1 nginx founders   15575 Nov 29 05:03 modernizr-5a6da2b38564a569777862a64bd1a526.js.gz
-rwxrwx--- 1 nginx founders   50145 Dec  8 03:11 modernizr.js
-rwxrwx--- 1 nginx founders   15575 Dec  8 03:11 modernizr.js.gz

```
