### PR TITLE
Change logger messages to debug

### DIFF
--- a/lib/non-stupid-digest-assets.rb
+++ b/lib/non-stupid-digest-assets.rb
@@ -37,16 +37,16 @@ module Sprockets
         full_non_digest_gz_path = "#{full_non_digest_path}.gz"
 
         if File.exists? full_digest_path
-          logger.info "Writing #{full_non_digest_path}"
+          logger.debug "Writing #{full_non_digest_path}"
           FileUtils.cp full_digest_path, full_non_digest_path
         else
-          logger.warn "Could not find: #{full_digest_path}"
+          logger.debug "Could not find: #{full_digest_path}"
         end
         if File.exists? full_digest_gz_path
-          logger.info "Writing #{full_non_digest_gz_path}"
+          logger.debug "Writing #{full_non_digest_gz_path}"
           FileUtils.cp full_digest_gz_path, full_non_digest_gz_path
         else
-          logger.warn "Could not find: #{full_digest_gz_path}"
+          logger.debug "Could not find: #{full_digest_gz_path}"
         end
       end
     end


### PR DESCRIPTION
These are very noisy and not worth outputting in my opinion (and sprockets shares the same opinion: https://github.com/sstephenson/sprockets/blob/master/lib/sprockets/manifest.rb#L213 )

Not being able to find gz versions is perfectly fine since images won't have them, so you always get warnings which seems wrong.
