### PR TITLE
Preserve mtime when creating the non-digested file

### DIFF
--- a/lib/non-stupid-digest-assets.rb
+++ b/lib/non-stupid-digest-assets.rb
@@ -38,13 +38,13 @@ module Sprockets
 
         if File.exists? full_digest_path
           logger.debug "Writing #{full_non_digest_path}"
-          FileUtils.cp full_digest_path, full_non_digest_path
+          FileUtils.copy_file full_digest_path, full_non_digest_path, :preserve_attributes
         else
           logger.debug "Could not find: #{full_digest_path}"
         end
         if File.exists? full_digest_gz_path
           logger.debug "Writing #{full_non_digest_gz_path}"
-          FileUtils.cp full_digest_gz_path, full_non_digest_gz_path
+          FileUtils.copy_file full_digest_gz_path, full_non_digest_gz_path, :preserve_attributes
         else
           logger.debug "Could not find: #{full_digest_gz_path}"
         end


### PR DESCRIPTION
FileUtils.cp does not copy the file-attributes from the source to the new
file.  With copy_file, this is possible. The third argument needs to be
"trueish", so a descriptive symbol suffices.

In effect, this copies over the mtime from the assets. This helps Webservers
to generate ETags based on the mtime which in turn can prevent the need to
retransfer a file if it hasn't changed since the last request.

Essentially, this patch is saving the money of all those who are paying for
bandwidth. As a side-effect, I'm not confused when I see the directory
listing.
