### PR TITLE
Refactor the #whitelisted_files method

### DIFF
--- a/lib/non-stupid-digest-assets.rb
+++ b/lib/non-stupid-digest-assets.rb
@@ -13,12 +13,7 @@ module NonStupidDigestAssets
     def whitelisted_files(files)
       files.select do |file, info|
         whitelist.any? do |item|
-          case item
-          when Regexp
-            info['logical_path'] =~ item
-          else
-            info['logical_path'] == item
-          end
+          item === info['logical_path']
         end
       end
     end


### PR DESCRIPTION
Because

```
    case x
    when Regexp
      y =~ x
    else
      y == x
    end
```

is the same as

```
   x === y
```

assuming that `x` is a Regexp or a String.
