### PR TITLE
Change README advice to use +=

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ If you want to whitelist non-digest assets for only certain files, you can confi
 ```ruby
 # config/initializers/non_digest_assets.rb
 
-NonStupidDigestAssets.whitelist = [/tinymce\/.*/, "image.png"]
+NonStupidDigestAssets.whitelist += [/tinymce\/.*/, "image.png"]
 ```
 
 Be sure to give either a regex that will match the right assets or the logical path of the asset in question.


### PR DESCRIPTION
Since NonStupidDigestAssets.whitelist is an empty array, the array
can be added to rather than replaced. This better enables gem authors
to depend on this gem and add their own assets to the whitelist.
