### PR TITLE
Don't copy assets that already exist

### DIFF
--- a/lib/non-stupid-digest-assets.rb
+++ b/lib/non-stupid-digest-assets.rb
@@ -31,17 +31,17 @@ module Sprockets
         full_non_digest_path = File.join dir, info['logical_path']
         full_non_digest_gz_path = "#{full_non_digest_path}.gz"
 
-        if File.exists? full_digest_path
+        if File.exists?(full_digest_path) && !File.exists?(full_non_digest_path)
           logger.debug "Writing #{full_non_digest_path}"
           FileUtils.copy_file full_digest_path, full_non_digest_path, :preserve_attributes
         else
-          logger.debug "Could not find: #{full_digest_path}"
+          logger.debug "Could not find or already exists: #{full_digest_path}"
         end
-        if File.exists? full_digest_gz_path
+        if File.exists?(full_digest_gz_path) && !File.exists?(full_non_digest_gz_path)
           logger.debug "Writing #{full_non_digest_gz_path}"
           FileUtils.copy_file full_digest_gz_path, full_non_digest_gz_path, :preserve_attributes
         else
-          logger.debug "Could not find: #{full_digest_gz_path}"
+          logger.debug "Could not find or already exists: #{full_digest_gz_path}"
         end
       end
     end


### PR DESCRIPTION
I got an exception when deploying to Heroku, saying that certain assets already exist in the non-digest form. This change handles that case.
