### PR TITLE
Use symbolic links in place of copying the whole files

### DIFF
--- a/lib/non-stupid-digest-assets.rb
+++ b/lib/non-stupid-digest-assets.rb
@@ -33,13 +33,13 @@ module Sprockets
 
         if File.exists? full_digest_path
           logger.debug "Writing #{full_non_digest_path}"
-          FileUtils.copy_file full_digest_path, full_non_digest_path, :preserve_attributes
+          FileUtils.ln_s full_digest_path, full_non_digest_path, :force => true
         else
           logger.debug "Could not find: #{full_digest_path}"
         end
         if File.exists? full_digest_gz_path
           logger.debug "Writing #{full_non_digest_gz_path}"
-          FileUtils.copy_file full_digest_gz_path, full_non_digest_gz_path, :preserve_attributes
+          FileUtils.ln_s full_digest_gz_path, full_non_digest_gz_path, :force => true
         else
           logger.debug "Could not find: #{full_digest_gz_path}"
         end


### PR DESCRIPTION
Should save time when deploying + disk space on the production severs without impacting Nginx or Apache performance.