### PR TITLE
Sprockets::Manifest.compile should return paths

### DIFF
--- a/lib/non-stupid-digest-assets.rb
+++ b/lib/non-stupid-digest-assets.rb
@@ -23,7 +23,7 @@ end
 module Sprockets
   class Manifest
     def compile_with_non_digest *args
-      compile_without_non_digest *args
+      paths = compile_without_non_digest *args
 
       NonStupidDigestAssets.files(files).each do |(digest_path, info)|
         full_digest_path = File.join dir, digest_path
@@ -44,6 +44,7 @@ module Sprockets
           logger.debug "Could not find: #{full_digest_gz_path}"
         end
       end
+      paths
     end
 
     alias_method_chain :compile, :non_digest


### PR DESCRIPTION
Sprockets::Manifest.compile changed to return paths.

https://github.com/sstephenson/sprockets/commit/0e7558a6fae1488a9afe4f541271f1c724909f78#diff-210127843b227645ec53849779cf3f34

so, I simply pipe returns from origin compile.