### PR TITLE
Ensure `Sprockets::Manifest` is loaded

### DIFF
--- a/lib/non-stupid-digest-assets.rb
+++ b/lib/non-stupid-digest-assets.rb
@@ -1,3 +1,5 @@
+require "sprockets/manifest"
+
 module NonStupidDigestAssets
   mattr_accessor :whitelist
   @@whitelist = []

--- a/non-stupid-digest-assets.gemspec
+++ b/non-stupid-digest-assets.gemspec
@@ -17,4 +17,6 @@ Gem::Specification.new do |s|
   s.files         = %w(lib/non-stupid-digest-assets.rb LICENSE README.md)
   s.license       = 'MIT'
   s.require_path  = 'lib'
+
+  s.add_dependency "sprockets", ">= 2.0"
 end


### PR DESCRIPTION
Monkey-patching `Sprockets::Manifest` assumes that `sprockets` has
already been required and loaded.

If this is the case, the `alias_method_chain` call will raise a
`NameError`.