### PR TITLE
use Module#prepend instead of alias_method_chain to shut rails 5 up

### DIFF
--- a/lib/non-stupid-digest-assets.rb
+++ b/lib/non-stupid-digest-assets.rb
@@ -20,13 +20,10 @@ module NonStupidDigestAssets
       end
     end
   end
-end
 
-module Sprockets
-  class Manifest
-    def compile_with_non_digest *args
-      paths = compile_without_non_digest *args
-
+  module CompileWithNonDigest
+    def compile *args
+      paths = super
       NonStupidDigestAssets.files(files).each do |(digest_path, info)|
         full_digest_path = File.join dir, digest_path
         full_digest_gz_path = "#{full_digest_path}.gz"
@@ -48,7 +45,7 @@ module Sprockets
       end
       paths
     end
-
-    alias_method_chain :compile, :non_digest
   end
 end
+
+Sprockets::Manifest.prepend NonStupidDigestAssets::CompileWithNonDigest

--- a/non-stupid-digest-assets.gemspec
+++ b/non-stupid-digest-assets.gemspec
@@ -18,5 +18,8 @@ Gem::Specification.new do |s|
   s.license       = 'MIT'
   s.require_path  = 'lib'
 
+  s.required_ruby_version = ">= 2.0"
+  
   s.add_dependency "sprockets", ">= 2.0"
+
 end


### PR DESCRIPTION
this also requires `s.required_ruby_version = ">= 2.0"` since that's where `Module#prepend` was introduced. without this you get log noise in rails 5:
```
12:43:39 web.1  | DEPRECATION WARNING: alias_method_chain is deprecated. Please, use Module#prepend instead. From module, you can access the original method using super. (called from <class:Manifest> at /Users/jon/.rvm/gems/ruby-2.3.0/gems/non-stupid-digest-assets-1.0.6/lib/non-stupid-digest-assets.rb:52)
```