### PR TITLE
Send Module#prepend for Ruby 2.0 support

### DIFF
--- a/lib/non-stupid-digest-assets.rb
+++ b/lib/non-stupid-digest-assets.rb
@@ -48,4 +48,4 @@ module NonStupidDigestAssets
   end
 end
 
-Sprockets::Manifest.prepend NonStupidDigestAssets::CompileWithNonDigest
+Sprockets::Manifest.send(:prepend, NonStupidDigestAssets::CompileWithNonDigest)


### PR DESCRIPTION
`Module#prepend` is not public in Ruby 2.0 it became public in Ruby 2.1