### PR TITLE
Use the `assets` collection instead of `files` to make sure we get the right version

### DIFF
--- a/lib/non-stupid-digest-assets.rb
+++ b/lib/non-stupid-digest-assets.rb
@@ -5,17 +5,17 @@ module NonStupidDigestAssets
   @@whitelist = []
 
   class << self
-    def files(files)
-      return files if whitelist.empty?
-      whitelisted_files(files)
+    def assets(assets)
+      return assets if whitelist.empty?
+      whitelisted_assets(assets)
     end
 
     private
 
-    def whitelisted_files(files)
-      files.select do |file, info|
+    def whitelisted_assets(assets)
+      assets.select do |logical_path, digest_path|
         whitelist.any? do |item|
-          item === info['logical_path']
+          item === logical_path
         end
       end
     end
@@ -24,10 +24,10 @@ module NonStupidDigestAssets
   module CompileWithNonDigest
     def compile *args
       paths = super
-      NonStupidDigestAssets.files(files).each do |(digest_path, info)|
+      NonStupidDigestAssets.assets(assets).each do |(logical_path, digest_path)|
         full_digest_path = File.join dir, digest_path
         full_digest_gz_path = "#{full_digest_path}.gz"
-        full_non_digest_path = File.join dir, info['logical_path']
+        full_non_digest_path = File.join dir, logical_path
         full_non_digest_gz_path = "#{full_non_digest_path}.gz"
 
         if File.exists? full_digest_path


### PR DESCRIPTION
Previously we were using the `files` collection which contains all versions of all digest assets sorted chonologically. This meant that if an asset was reverted to a previous state (by `git revert` for instance) then the non-digest version of the asset would end up being the wrong version. See #42 for additional details on the problem.

By iterating over the `assets` hash instead of `files` we make sure that we're using the digest versions that the app considers to be "current". A nice side effect is that we also end up copying fewer files.

Fixes #42